### PR TITLE
Fixed typo that prevented forecast processing.

### DIFF
--- a/jquery.simplerWeather.js
+++ b/jquery.simplerWeather.js
@@ -103,7 +103,7 @@ Simple Weather Java Switches to DarkSky */
               low: getAltTemp( options.unit, weather.low )
             };
 
-            if( options.forcast &&
+            if( options.forecast &&
               parseInt( options.forecastdays ) !== "NaN" ) {
 
               weather.forecast = [];


### PR DESCRIPTION
There was a typo that prevented the forecast information from being processed, regardless of the corresponding option.
I don't know which tool/service you used to create the minified code, therefore I haven't updated that file.